### PR TITLE
fix: Remove Python and JavaScript scanning from CodeQL analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'python', 'javascript-typescript', 'actions' ]
+        language: [ 'actions' ]
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
This pull request makes a small change to the CodeQL analysis workflow configuration by limiting the analysis to only GitHub Actions code.

- Workflow configuration update:
  * [`.github/workflows/codeql-analysis.yml`](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188L24-R24): Changed the CodeQL analysis matrix to analyze only `'actions'` instead of `'python'`, `'javascript-typescript'`, and `'actions'`.…ere is no Python code in the repo for the moment