### PR TITLE
fix: skip docs deploy when GitHub Pages is not enabled

### DIFF
--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -7,6 +7,7 @@ applyTo: "docs/**/*,agents/*/docs/**/*"
 - Docs stack: Sphinx with `sphinx_autodoc_typehints`; install docs deps once via `uv run poe docs-install` (uses the `docs` group).
 - Build everything: `uv run poe docs` (per-agent + unified). Per-agent only: `uv run --group docs python scripts/generate_docs.py --agents-only --agents <agent>`. Unified only: `uv run --group docs python scripts/generate_docs.py --unified-only`.
 - Sources: unified at `docs/source`; per-agent at `agents/<agent>/docs/source`. Generated output: `docs/generated` and `agents/<agent>/docs/generated` — do not edit or commit generated HTML; rely on the GitHub Actions docs workflow to produce/publish generated content.
+- Publishing: the `python-docs.yml` workflow always builds + uploads the Pages artifact, then conditionally deploys via `actions/deploy-pages` only when GitHub Pages is enabled for the repo. Skipped deploys are expected on fresh template clones and surface as a workflow notice rather than a failure.
 - PYTHONPATH for builds comes from `scripts/generate_docs.py`; ensure agents exist or the script exits early.
 - Keep `_autosummary` directories out of version control (build script cleans them). When adding extensions, note `sphinx_autodoc_typehints` import is intentionally unused.
 - Preferred Python: 3.13 (3.12 ok). Run commands via `uv run ...` to ensure the project env is active.

--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -25,6 +25,9 @@ jobs:
     name: build docs
     runs-on: ubuntu-latest
 
+    outputs:
+      pages-enabled: ${{ steps.pages-status.outputs.enabled }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -45,9 +48,41 @@ jobs:
         with:
           path: docs/generated
 
+      - name: Check GitHub Pages status
+        id: pages-status
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if ! status=$(curl --silent --show-error -o /dev/null -w "%{http_code}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${REPO}/pages"); then
+            echo "::error::Failed to query GitHub Pages API for ${REPO} (network or TLS error)." >&2
+            exit 1
+          fi
+          # Defense-in-depth: only allow a numeric HTTP status code into the conditional.
+          if [[ ! "$status" =~ ^[0-9]+$ ]]; then
+            echo "::error::Unexpected non-numeric HTTP status from Pages API: '${status}'" >&2
+            exit 1
+          fi
+          if [[ "$status" == "200" ]]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "GitHub Pages is enabled for ${REPO}; deploy job will run."
+          elif [[ "$status" == "404" ]]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::GitHub Pages is not enabled for ${REPO}; skipping deploy. Enable Pages in repository Settings > Pages to publish the built docs (the artifact is still uploaded)."
+          else
+            echo "::error::Unexpected HTTP status ${status} from Pages API for ${REPO}." >&2
+            exit 1
+          fi
+
   deploy:
     name: deploy to GitHub Pages
     needs: build
+    if: needs.build.outputs.pages-enabled == 'true'
     runs-on: ubuntu-latest
 
     environment:

--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Check GitHub Pages status
         id: pages-status
         env:
+          API_URL: ${{ github.api_url }}
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
@@ -59,7 +60,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${REPO}/pages"); then
+            "${API_URL}/repos/${REPO}/pages"); then
             echo "::error::Failed to query GitHub Pages API for ${REPO} (network or TLS error)." >&2
             exit 1
           fi

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -573,5 +573,6 @@ Documentation is built using Sphinx and published to GitHub Pages via the [docs 
 - Install docs deps: `uv run poe docs-install`
 - Build locally: `uv run poe docs`
 - The docs workflow triggers on pushes to `main` when documentation sources, agent source code, or the docs generation script change.
+- The workflow always builds the docs and uploads a Pages artifact. The `deploy to GitHub Pages` job is **conditional** on Pages being enabled for the repository: if Pages is not enabled (the default for fresh template clones), the deploy job is skipped with a workflow notice and the overall run still succeeds. Enable Pages under **Settings → Pages** (source: *GitHub Actions*) to start publishing.
 
 > **Note:** `docs/generated/` and `agents/*/docs/generated/` are produced by CI; do not edit or commit them.

--- a/docs/manual/docs-build-guide.md
+++ b/docs/manual/docs-build-guide.md
@@ -35,6 +35,7 @@ How to build API docs for the template and each agent.
 ## CI recommendation
 - Add a GitHub Actions job that installs the docs group (`uv sync --group docs`) and runs `uv run poe docs`.
 - Fail the job on Sphinx warnings/errors; optionally upload `docs/generated` as an artifact.
+- If you publish to GitHub Pages, the bundled `python-docs.yml` workflow already does this. It always builds and uploads the artifact, and only runs the `deploy to GitHub Pages` job when Pages is enabled for the repo (probed via the Pages REST API). For fresh template clones, the deploy job skips gracefully with a workflow notice until you enable Pages under **Settings → Pages** (source: *GitHub Actions*).
 
 ## Per-agent tasks
 - Agents may expose `poe docs` locally; agent1 example runs `uv run python ../../scripts/generate_docs.py --agents-only --agents agent1`.


### PR DESCRIPTION
## Summary

`python-docs.yml` has been failing on **every push to `main`** since PR #51 because the `deploy to GitHub Pages` job 404s — Pages isn't enabled in this template repository. The `build docs` job itself succeeds and uploads the artifact correctly. Latest failed run: [#26873800372](https://github.com/pmalarme/python-agent-template/actions/runs/26873800372).

This PR makes the deploy job **conditional on Pages being enabled**, so the workflow turns green in the default (Pages-disabled) state of the template, while still publishing automatically once a consumer enables Pages.

## Changes

**`.github/workflows/python-docs.yml`**
- Expose a new `pages-enabled` output from the `build` job.
- Add a `Check GitHub Pages status` step that calls `GET /repos/{owner}/{repo}/pages` via `curl` and writes `enabled=true` on `200`, `enabled=false` on `404`, fails the step on any other status.
- Handle curl transport failures explicitly (`--show-error`, explicit `if !`) and validate the captured value is numeric (`^[0-9]+$`) before branching on it — defense-in-depth so we never feed a malformed value into the deploy gate.
- Gate the `deploy` job with `if: needs.build.outputs.pages-enabled == 'true'`. Skipped deploys surface as a workflow notice (`::notice::`), not a failure.

The artifact upload still runs unconditionally, so the docs build itself remains validated end-to-end on every push regardless of Pages status.

**Documentation**
- `DEVELOPMENT.md` — describe the conditional-deploy behaviour and how to enable Pages (`Settings → Pages → Source: GitHub Actions`).
- `docs/manual/docs-build-guide.md` — same note in the CI recommendation section.
- `.github/instructions/docs.instructions.md` — brief Copilot instruction so future agents know skipped deploys are expected on fresh template clones.

## Testing

- [x] `uv run poe markdown-code-lint` — all code blocks pass
- [x] Workflow YAML parses cleanly via PyYAML; `build.outputs.pages-enabled`, `deploy.if`, and `deploy.needs` all resolve correctly
- [x] Rubber-duck review of the gating logic; applied the recommended curl-error-handling fix

## What still needs verifying after merge

- A push to `main` should produce a green run with the deploy job skipped and a `GitHub Pages is not enabled…` workflow notice.
- After enabling Pages (`Settings → Pages → Source: GitHub Actions`), a subsequent push should run the deploy job to completion.

## Triage context

Closes the docs-workflow side of the open PR triage. Supersedes #81 (same intent, slightly cleaner curl error handling + documentation + Copilot instructions added). Recommend closing #81 once this merges.